### PR TITLE
Cdn support with Custom extension

### DIFF
--- a/examples/cartero_example_5/library/JQuery/bundle.json
+++ b/examples/cartero_example_5/library/JQuery/bundle.json
@@ -1,3 +1,3 @@
 {
-	"remoteFiles" : [ "http://code.jquery.com/jquery-1.10.1.min.js" ]
+	"remoteFiles" : [ { "fileName": "http://code.jquery.com/jquery-1.10.1.min.js?__82", "extension": "js" } ]
 }

--- a/lib/file.js
+++ b/lib/file.js
@@ -1,4 +1,5 @@
 var _ = require( "underscore" ),
+	_s = require("underscore.string"),
 	path = require( "path" ),
 	grunt = require( "grunt" );
 
@@ -19,7 +20,34 @@ function File( obj ) {
 
 /** Static functions **/
 
+File.isValidObjectDefinition = function(fileName){
+	if (_.isObject(fileName)){
+		if (_.has(fileName, "fileName") && _.has(fileName, "extension") && _.isString(fileName["fileName"]) && _.isString(fileName["extension"]) ){
+			return true;
+		} else {
+			throw new Error("Definition of dependency must be a string or and object with fileName and extension properties");
+		}
+	} else {
+		return false;
+	}
+};
+
+File.getFileName = function( fileName ) {
+	if (File.isValidObjectDefinition(fileName)){
+		return fileName["fileName"];
+	} else {
+		return fileName;
+	}
+};
+
 File.getFileExtension = function( fileName ) {
+	if (File.isValidObjectDefinition(fileName)){
+		var ext = fileName["extension"];
+		if(!_s.startsWith(ext, '.')){
+			ext = "."+ext;
+		}
+		return ext;
+	}
 	return fileName.substring( fileName.lastIndexOf( "." ) );
 };
 
@@ -70,7 +98,7 @@ File.isImageFileName = function( fileName ) {
 };
 
 File.isCDNFile = function( fileName ) {
-	return cdnFileRegex.test( fileName );
+	return cdnFileRegex.test(File.getFileName(fileName));
 };
 
 File.getFilesByType = function( files ) {
@@ -88,7 +116,7 @@ File.getFilesByType = function( files ) {
 File.mapAssetFileName = function( fileName, assetExtensionMap ) {
 	// don't map CDN file names
 	if( File.isCDNFile( fileName ) ) {
-		return fileName;
+		return File.getFileName(fileName);
 	}
 	var fileExt = File.getFileExtension( fileName );
 	var outExt = assetExtensionMap[ fileExt ];
@@ -111,7 +139,11 @@ File.prototype = {
 			return extension.substring( 1 );
 	},
 	getFileExtension : function() {
-		return File.getFileExtension( this.path );
+		if(File.isCDNFile(this.src)){
+			return File.getFileExtension( this.src );
+		} else {
+			return File.getFileExtension( this.path );
+		}
 	},
 	copy : function( srcDir, destDir ) {
 		// for CDN files, copy the src to the path, but don't do the actual file copy


### PR DESCRIPTION
By introducing "remoteFiles" option, we were able to define libraries that ended with "css" or "js" extensions that were stored remotely. The problem is that if the remoteFile didnt have an url that ended with "css" or "js", there was no proper way of detecting the extension. As suggested in https://github.com/rotundasoftware/cartero/issues/7 , a good way would be to be able to allow the developer to specify the extension.

So, goal here is to allow any kind of URL to be used in "remoteFiles" options in the bundle.json. This was done by adding support for object definition. Eg: 

```
 {
 "remoteFiles" : [ { "fileName": "http://code.jquery.com/jquery-1.10.1.min.js?__82", "extension": "js" } ]
 }
```

Let me know of any problems. I did some tests in a few projects and it looks like its working fine. I modified the new sample project as well. Any suggestions are welcomed.
