### PR TITLE
Add baseUrl option for asset resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ At run time, the HTML tags needed to load a parcel's js and css bundles, as well
 
 --outputDirUrl, -o      The base url of the cartero output directory (e.g. "/assets"). Defaults to "/".
 
+--baseUrl, -b           The base url where the output directory (e.g. "/assets") will be served by the webserver. Defaults to "/".
+
 --help, -h              Show this message.
 ```
 
@@ -190,6 +192,7 @@ The same resolution algorithm can be employed at run time (on the server side) v
 * `assetTypes` (default: [ 'style', 'image' ]) - The keys in package.json files that enumerate assets that should be copied to the cartero output directory.
 * `assetTypesToConcatenate` (default: [ 'style' ]) - A subset of `assetTypes` that should be concatenated into bundles. Note JavaScript files are special cased and are always both included and bundled.
 * `outputDirUrl` (default: '/') - The base url of the output directory.
+* `baseUrl` (default: '/') - The base url where the output directory will be served by the webserver.
 * `appTransforms` (default: undefined) - An array of [transform modules](https://github.com/substack/module-deps#transforms) names / paths or functions to be applied to all packages in directories in the `appTransformDirs` array.
 * `appTransformDirs` (default: [ parcelsDir ]) - `appTransforms` are applied to any packages that are within one of the directories in this array. (The recursive search is stopped on `node_module` directories.)
 * `packageTransform` (default: undefined) - A function that transforms package.json files before they are used. The function should be of the signature `function( pkgJson, pkgPath )` and return the parsed, transformed package object. This feature can be used to add default values to package.json files or alter the package.json of third party modules without modifying them directly.

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -16,6 +16,7 @@ var argv = minimist( process.argv.slice(2),
 			transform : 't',
 			postProcessor : 'p',
 			outputDirUrl : 'u',
+			baseUrl : 'b',
 			help : 'h'
 		},
 		boolean : [ 'keepSeparate', 'watch', 'help', 'maps' ]
@@ -48,7 +49,8 @@ var carteroOptions = {
 	defaultTransforms : argv.transform,
 	outputDirUrl : argv.outputDirUrl,
 	packageTransform : argv.packageTransform,
-	postProcessors : argv.postProcessor
+	postProcessors : argv.postProcessor,
+	baseUrl : argv.baseUrl
 };
 
 var c = cartero( viewDirPath, outputDirPath, carteroOptions );

--- a/bin/help.txt
+++ b/bin/help.txt
@@ -1,5 +1,7 @@
 --outputDirUrl, -o      The base url of the cartero output directory (e.g. "/assets"). Defaults to "/".
 
+--baseUrl, -b           The base url where the output directory (e.g. "/assets") will be served by the webserver. Defaults to "/".
+
 --transform, -t         Name or path of a default transform. (See discussion of `defaultTransforms` option.)
 
 --postProcessor, -p     The name of a post processor module to apply to assets (e.g. uglifyify, etc.).


### PR DESCRIPTION
Hi, Thanks for merging the other pull request :)

Here If found another use case of interest: in my app I'm serving the `/assets` directory under an specific url (let's say `http://my.domain/app/assets/`), but the assetResolver transform is replacing all the url(...) links in the css for the url in the asset folder as an absolute url (ie `/f2e88779520b983cdd117bce5129c80e6f271623/img/masterSprite.png`).

I need to tell the resolver that I'm serving those files in `http://my.domain/app/assets/f2e88779520b983cdd117bce5129c80e6f271623/img/masterSprite.png` instead. I think that having an extra option called baseUrl will make the trick, what do you think?

Thanks!
F
