### PR TITLE
licenses in package.json is deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,12 +16,7 @@
   "bugs": {
     "url": "https://github.com/rotundasoftware/cartero/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/rotundasoftware/cartero/blob/master/LICENSE-MIT"
-    }
-  ],
+  "license": "MIT",
   "scripts": {
     "test": "tape test/test.js"
   },


### PR DESCRIPTION
Read more [here](https://docs.npmjs.com/files/package.json#license).