### PR TITLE
update modules in package.json to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,28 +32,28 @@
     "commonjs"
   ],
   "devDependencies": {
-    "tape": "^2.12.2"
+    "tape": "^4.2.0"
   },
   "dependencies": {
     "async": "^1.4.0",
-    "browserify": "^10.2.6",
+    "browserify": "^11.0.1",
     "concat-stream": "^1.4.4",
     "factor-bundle": "^2.5.0",
-    "glob": "^3.2.8",
+    "glob": "^5.0.14",
     "globwatcher": "^1.3.0",
     "inherits": "^2.0.1",
-    "minimist": "0.0.8",
-    "mkdirp": "^0.3.5",
-    "npmlog": "0.0.6",
+    "minimist": "1.1.3",
+    "mkdirp": "^0.5.1",
+    "npmlog": "1.2.1",
     "parcel-finder": "^0.2.3",
     "parcelify": "^2.1.0",
     "path-mapper": "^0.1.3",
     "replace-string-transform": "^0.1.0",
-    "resolve": "^0.6.2",
+    "resolve": "^1.1.6",
     "rimraf": "^2.2.6",
-    "stream-combiner": "^0.0.4",
+    "stream-combiner": "^0.2.2",
     "through": "^2.3.4",
-    "through2": "^0.4.1",
+    "through2": "^2.0.0",
     "underscore": "^1.4.4",
     "watchify": "^3.2.3"
   }


### PR DESCRIPTION
Current modules in package.json are outdated, some by several major releases. Updating to latest for all modules to get bug fixes.