### PR TITLE
Fix error propagation when browseify fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -361,6 +361,7 @@ Cartero.prototype.processMains = function( callback ) {
 			if( err ) {
 				delete err.stream; // gets messy if we dump this to the console
 				log.error( '', err );
+				_this.emit( 'error', err);
 				return;
 			}
 


### PR DESCRIPTION
@dgbeck I'm having a problem when browserify fails. The error is not being propagating and therefore my build process is not failing even if there is an error. It looks like a logic change what I'm proposing but I'm not super sure about re-emiting the error in watch mode. Opinions?

Thanks
F