### PR TITLE
Remove pathMapper in package json and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 
-### v4.0.0
-* BREAKING CHANGE: Change metaData.json assetMap to contain path from asset package Id to asset filename (insted of just asset filename)
-* NOTE: hooks written for cartero < v4.0.0 will NOT work with cartero v4.0.0 and later.
+### v6.0.0
+* BREAKING CHANGE: Change metaData.json assetMap to contain path from asset package Id to asset filename (insted of just asset filename) and change all urls to relative to appRootDir
+* NOTE: hooks written for cartero < v6.0.0 will NOT work with cartero v6.0.0 and later.
 * There were no API changes in this version but since a hook is required we bumped the major version number.
 
 ### v3.0.0

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014 Rotunda Software, LLC.
+Copyright (c) 2015 Rotunda Software, LLC.
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "npmlog": "1.2.1",
     "parcel-finder": "^0.2.3",
     "parcelify": "^2.1.0",
-    "path-mapper": "^0.1.3",
     "replace-string-transform": "^0.1.0",
     "resolve": "^1.1.6",
     "rimraf": "^2.2.6",


### PR DESCRIPTION
@dgbeck I updated your changelog, I'm not sure if it's automatic :) Btw I can `npm install cartero@6.0.0` but it seems like it's an old version still (formatVersion is still 2 and should be 3 in the latest version)