### PR TITLE
Update cmd.js

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -43,13 +43,14 @@ outputDirPath = resolvePath( outputDirPath );
 var watch = argv.watch;
 
 var appTransformDirs = argv.transformDirs;
+var appTransforms = argv.transform;
 if( typeof appTransformDirs === 'string' ) appTransformDirs = [ appTransformDirs ];
-if( typeof transform === 'string' ) transform = [ transform ];
+if( typeof appTransforms === 'string' ) appTransforms = [ appTransforms ];
 var carteroOptions = {
 	keepSeparate : argv.keepSeparate,
 	sourceMaps : argv.maps,
 	watch : watch,
-	appTransforms : argv.transform,
+	appTransforms : appTransforms,
 	appTransformDirs : appTransformDirs,
 	outputDirUrl : argv.outputDirUrl,
 	packageTransform : argv.packageTransform,

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -44,7 +44,7 @@ var watch = argv.watch;
 
 var appTransformDirs = argv.transformDirs;
 if( typeof appTransformDirs === 'string' ) appTransformDirs = [ appTransformDirs ];
-
+if( typeof transform === 'string' ) transform = [ transform ];
 var carteroOptions = {
 	keepSeparate : argv.keepSeparate,
 	sourceMaps : argv.maps,


### PR DESCRIPTION
cli transform flag was not working correctly when I tried to use the example from the documentation
https://github.com/rotundasoftware/cartero#application-level-transforms

Previous behaviour was passing in transform flag as a string when calling cartero
https://github.com/rotundasoftware/cartero/blob/master/bin/cmd.js#L59

Lead to error when concat was called for appTransforms
https://github.com/rotundasoftware/cartero/blob/master/index.js#L275

the value of this.appTransforms was a string rather than an array.