### PR TITLE
Update npmlog dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "inherits": "^2.0.1",
     "minimist": "1.1.3",
     "mkdirp": "^0.5.1",
-    "npmlog": "1.2.1",
+    "npmlog": "^4.1.2",
     "parcel-finder": "^0.2.3",
     "parcelify": "^2.1.0",
     "replace-string-transform": "^0.1.0",


### PR DESCRIPTION
I was encountering this issue: https://github.com/npm/npmlog/issues/50

Syntax errors in client-side JS were throwing the following error while bundling:

```
info   /Users/cooldude/Projects/zephyr-bug/src/pages/app/app-client.js
/Users/cooldude/Projects/ui-zephyr/node_modules/npmlog/log.js:145
      arg.stack = stack = arg.stack + ''
                ^

TypeError: Cannot set property stack of SyntaxError which has only a getter
    at EventEmitter.<anonymous> (/Users/cooldude/Projects/ui-zephyr/node_modules/npmlog/log.js:145:17)
    at EventEmitter.<anonymous> (/Users/cooldude/Projects/ui-zephyr/node_modules/npmlog/log.js:230:21)
    at Readable.<anonymous> (/Users/cooldude/Projects/ui-zephyr/node_modules/cartero/index.js:421:9)
 ```