### PR TITLE
Emit event on metaData written

### DIFF
--- a/index.js
+++ b/index.js
@@ -874,16 +874,20 @@ Cartero.prototype.writeMetaDataFile = function( callback ) {
 		return entryPointMapMemo;
 	}, {} );
 
-	var metaData = JSON.stringify( {
+	var metaData = {
 		formatVersion : 4,
 		packageMap : packageMap,
 		entryPointMap : entryPointMap,
 		assetsRequiredByEntryPoint : _this.assetsRequiredByEntryPoint,
 		assetMap: _this.assetMap
-	}, null, 4 );
+	};
 
-	fs.writeFile( metaDataFilePath, metaData, function( err ) {
+	var metaDataAsJson = JSON.stringify( metaData, null, 4 );
+
+	fs.writeFile( metaDataFilePath, metaDataAsJson, function( err ) {
 		if( err ) return callback( err );
+
+		_this.emit( 'metaDataWritten', metaDataFilePath, metaData );
 
 		callback();
 	} );


### PR DESCRIPTION
Hi @pepoviola ! Did this while working on new issue tracker.

We can hook into this event while cartero runs on `watch` mode, to re-write any HTML entry point for static Apps.

By passing the `metaData` object we even avoid having to read `metaData.json` from the filesystem.

You can see it in use [here](https://github.com/rotundasoftware/github-issue-tracker/blob/switch-to-modui/webapp/build/cartero.js#L193-L215).

Let me know what you think, thanks!